### PR TITLE
Remove redundant logprint

### DIFF
--- a/app/src/main/java/es/chiteroman/bootloaderspoofer/Xposed.java
+++ b/app/src/main/java/es/chiteroman/bootloaderspoofer/Xposed.java
@@ -103,9 +103,6 @@ public final class Xposed implements IXposedHookLoadPackage {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        XposedBridge.log("[BootloaderSpoofer] Loaded " + map.size() + " keys!");
-        XposedBridge.log("[BootloaderSpoofer] Loaded " + numberOfCerts + " certificates!");
     }
 
     private static KeyPair parseKeyPair(String key) throws Exception {


### PR DESCRIPTION
  *Apps can read log buffer of their own. Since modules actually 
   runs in target app's process, Xposed bridge logs are readable
   by app and become a detection method of injection. Nowadays,
   real world apps start to use this method (such as iMobile Pay) to
   detect Xposed and Zygisk injection, so remove redundant logs
   to prevent possible issues. 

 * Apps probably have 100 ways to detect injection, so best effort is to
    implement this module remotely, but that is a different story.